### PR TITLE
fix bug where esphome would not build anything

### DIFF
--- a/template/Dockerfile
+++ b/template/Dockerfile
@@ -20,7 +20,7 @@ RUN \
 COPY platformio.ini /opt/pio/
 
 RUN \
-    pip2 install --no-cache-dir --no-binary :all: platformio==3.6.7 \
+    pip2 install --no-cache-dir --no-binary :all: platformio==4.0.3 \
     # Change some platformio settings
     && platformio settings set enable_telemetry No \
     && platformio settings set check_libraries_interval 1000000 \

--- a/template/Dockerfile.hassio
+++ b/template/Dockerfile.hassio
@@ -21,7 +21,7 @@ RUN \
 COPY platformio.ini /opt/pio/
 
 RUN \
-    pip2 install --no-cache-dir --no-binary :all: platformio==3.6.7 \
+    pip2 install --no-cache-dir --no-binary :all: platformio==4.0.3 \
     # Change some platformio settings
     && platformio settings set enable_telemetry No \
     && platformio settings set check_libraries_interval 1000000 \


### PR DESCRIPTION
... by updating platformio dependency to latest.

When attempt to build+upload with `platformio@3.6.7`, esphome fails with this log:
```
INFO Reading configuration...
INFO Detected timezone 'CET' with UTC offset 1 and daylight savings time from 03/29/20 02:00:00 to 10/25/20 03:00:00
INFO Generating C++ source...
INFO Compiling app...
INFO Running:  platformio run -d /config/electricity_meter
ERROR Running command failed: 
ERROR Please try running platformio run -d /config/electricity_meter locally.
```

Running that command in the docker container reveals this rather cryptic log:
```
Traceback (most recent call last):
  File "/usr/local/bin/platformio", line 11, in <module>
    load_entry_point('platformio==3.6.7', 'console_scripts', 'platformio')()
  File "/usr/local/lib/python2.7/dist-packages/platformio/__main__.py", line 123, in main
    maintenance.on_platformio_exception(e)
  File "/usr/local/lib/python2.7/dist-packages/platformio/maintenance.py", line 64, in on_platformio_exception
    telemetry.on_exception(e)
  File "/usr/local/lib/python2.7/dist-packages/platformio/telemetry.py", line 358, in on_exception
    mp = MeasurementProtocol()
  File "/usr/local/lib/python2.7/dist-packages/platformio/telemetry.py", line 67, in __init__
    self['cid'] = app.get_cid()
  File "/usr/local/lib/python2.7/dist-packages/platformio/app.py", line 341, in get_cid
    cid = get_state_item("cid")
  File "/usr/local/lib/python2.7/dist-packages/platformio/app.py", line 283, in get_state_item
    with State() as data:
  File "/usr/local/lib/python2.7/dist-packages/platformio/app.py", line 91, in __init__
    self.path = join(util.get_home_dir(), "appstate.json")
  File "/usr/local/lib/python2.7/dist-packages/platformio/util.py", line 253, in get_home_dir
    assert isdir(home_dir)
AssertionError
```

I knew that the system worked on my host machine, though, so I started digging for differences and found the version mismatch. My Dockerfile looks like this, for anyone looking to fix this issue before the PR is merged:
```
FROM esphome/esphome

COPY platformio.ini /opt/pio/

RUN \
    pip2 install --no-cache-dir --no-binary :all: platformio==4.0.3 \
    # Change some platformio settings
    && platformio settings set enable_telemetry No \
    && platformio settings set check_libraries_interval 1000000 \
    && platformio settings set check_platformio_interval 1000000 \
    && platformio settings set check_platforms_interval 1000000 \
    # Build an empty platformio project to force platformio to install all fw build dependencies
    # The return-code will be non-zero since there's nothing to build.
    && (platformio run -d /opt/pio; echo "Done") \
    && rm -rf /opt/pio/
```

Note: copy `platformio.ini` into the context directory from [here](https://github.com/esphome/esphome-docker-base/blob/master/platformio.ini)

Note: I haven't tested any builds other than the (non-hass.io) amd64 one.