### PR TITLE
Bump platformio-espressif8266 to 2.6.2

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -12,8 +12,8 @@ framework = arduino
 build_flags = -fail
 
 ; LATEST+RECOMMENDED ESP8266
-[env:espressif8266-2.7.3]
-platform = espressif8266@2.6.1
+[env:espressif8266-2.7.4]
+platform = espressif8266@2.6.2
 board = nodemcuv2
 framework = arduino
 build_flags = -fail


### PR DESCRIPTION
https://github.com/platformio/platform-espressif8266/releases/tag/v2.6.2

https://github.com/esp8266/Arduino/releases/tag/2.7.4