### PR TITLE
Update dependencies

### DIFF
--- a/Dockerfile.lint
+++ b/Dockerfile.lint
@@ -8,7 +8,7 @@ RUN \
         clang-format-7=1:7-3~ubuntu0.18.04.1 \
         clang-tidy-7=1:7-3~ubuntu0.18.04.1 \
         patch=2.7.6-2ubuntu1.1 \
-        software-properties-common=0.96.24.32.13 \
+        software-properties-common=0.96.24.32.14 \
     # Update to latest git version because of github actions
     # https://github.com/actions/checkout/issues/126
     && apt-add-repository ppa:git-core/ppa \

--- a/platformio.ini
+++ b/platformio.ini
@@ -20,7 +20,7 @@ build_flags = -fail
 
 ; LATEST+RECOMMENDED ESP32
 [env:espressif32-1.0.4]
-platform = espressif32@1.12.4
+platform = espressif32@2.0.0
 board = nodemcu-32s
 framework = arduino
 build_flags = -fail

--- a/template/Dockerfile
+++ b/template/Dockerfile
@@ -5,13 +5,13 @@ RUN \
     # Use pinned versions so that we get updates with build caching
     && apt-get install -y --no-install-recommends \
         python3=3.6.7-1~18.04 \
-        python3-pip=9.0.1-2.3~ubuntu1.18.04.1 \
+        python3-pip=9.0.1-2.3~ubuntu1.18.04.2 \
         python3-setuptools=39.0.1-2 \
         python3-pil=5.1.0-1ubuntu0.3 \
         python3-cryptography=2.1.4-1ubuntu1.3 \
         iputils-ping=3:20161105-1ubuntu3 \
         git=1:2.17.1-1ubuntu0.7 \
-        curl=7.58.0-2ubuntu3.9 \
+        curl=7.58.0-2ubuntu3.10 \
     && rm -rf \
         /tmp/* \
         /var/{cache,log}/* \
@@ -25,8 +25,8 @@ COPY platformio.ini /opt/pio/
 RUN \
     # Ubuntu python3-pip is missing wheel
     pip3 install --no-cache-dir \
-        wheel==0.34.2 \
-        platformio==4.3.4 \
+        wheel==0.35.1 \
+        platformio==5.0.1 \
     # Change some platformio settings
     && platformio settings set enable_telemetry No \
     && platformio settings set check_libraries_interval 1000000 \

--- a/template/Dockerfile.hassio
+++ b/template/Dockerfile.hassio
@@ -8,13 +8,13 @@ RUN \
     # Use pinned versions so that we get updates with build caching
     && apt-get install -y --no-install-recommends \
         python3=3.6.7-1~18.04 \
-        python3-pip=9.0.1-2.3~ubuntu1.18.04.1 \
+        python3-pip=9.0.1-2.3~ubuntu1.18.04.2 \
         python3-setuptools=39.0.1-2 \
         python3-pil=5.1.0-1ubuntu0.3 \
         python3-cryptography=2.1.4-1ubuntu1.3 \
         iputils-ping=3:20161105-1ubuntu3 \
         git=1:2.17.1-1ubuntu0.7 \
-        curl=7.58.0-2ubuntu3.9 \
+        curl=7.58.0-2ubuntu3.10 \
         nginx=1.14.0-0ubuntu1.7 \
     && rm -rf \
         /tmp/* \
@@ -29,8 +29,8 @@ COPY platformio.ini /opt/pio/
 RUN \
     # Ubuntu python3-pip is missing wheel
     pip3 install --no-cache-dir \
-        wheel==0.34.2 \
-        platformio==4.3.4 \
+        wheel==0.35.1 \
+        platformio==5.0.1 \
     # Change some platformio settings
     && platformio settings set enable_telemetry No \
     && platformio settings set check_libraries_interval 1000000 \


### PR DESCRIPTION
- software-properties-common `0.96.24.32.13` -> `0.96.24.32.14`
- platform-espressif32 `1.12.4` -> [`2.0.0`](https://github.com/platformio/platform-espressif32/releases/tag/v2.0.0)
- python3-pip `9.0.1-2.3~ubuntu1.18.04.1` -> `python3-pip=9.0.1-2.3~ubuntu1.18.04.2`
- curl `7.58.0-2ubuntu3.9` -> `7.58.0-2ubuntu3.10`
- wheel `0.34.2` -> `0.35.1`
- platformio `4.3.4` -> `5.0.1`