### PR TITLE
Switch to debian

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
         run: |
           docker pull "${BUILD_TO}:dev" || true
       - name: Register QEMU binfmt
-        run: docker run --rm --privileged multiarch/qemu-user-static:5.0.0-2 --reset -p yes
+        run: docker run --rm --privileged multiarch/qemu-user-static:5.2.0-2 --reset -p yes
       - run: |
           docker build \
             --file "${DOCKERFILE}" \

--- a/.github/workflows/release-dev.yml
+++ b/.github/workflows/release-dev.yml
@@ -41,7 +41,7 @@ jobs:
         run: |
           docker pull "${BUILD_TO}:dev" || true
       - name: Register QEMU binfmt
-        run: docker run --rm --privileged multiarch/qemu-user-static:5.0.0-2 --reset -p yes
+        run: docker run --rm --privileged multiarch/qemu-user-static:5.2.0-2 --reset -p yes
       - run: |
           docker build \
             --tag "${BUILD_TO}:${TAG}" \
@@ -81,7 +81,7 @@ jobs:
         run: |
           docker pull "${BUILD_TO}:dev" || true
       - name: Register QEMU binfmt
-        run: docker run --rm --privileged multiarch/qemu-user-static:5.0.0-2 --reset -p yes
+        run: docker run --rm --privileged multiarch/qemu-user-static:5.2.0-2 --reset -p yes
       - run: |
           docker build \
             --tag "${BUILD_TO}:${TAG}" \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
         run: |
           docker pull "${BUILD_TO}:latest" || true
       - name: Register QEMU binfmt
-        run: docker run --rm --privileged multiarch/qemu-user-static:5.0.0-2 --reset -p yes
+        run: docker run --rm --privileged multiarch/qemu-user-static:5.2.0-2 --reset -p yes
       - run: |
           docker build \
             --tag "${BUILD_TO}:${TAG}" \
@@ -69,7 +69,7 @@ jobs:
           python-version: '3.8'
 
       - name: Register QEMU binfmt
-        run: docker run --rm --privileged multiarch/qemu-user-static:5.0.0-2 --reset -p yes
+        run: docker run --rm --privileged multiarch/qemu-user-static:5.2.0-2 --reset -p yes
       - name: Set TAG
         run: |
           TAG="${GITHUB_REF#refs/tags/v}"

--- a/Dockerfile.lint
+++ b/Dockerfile.lint
@@ -5,15 +5,10 @@ RUN \
     apt-get update \
     # Use pinned versions so that we get updates with build caching
     && apt-get install -y --no-install-recommends \
-        clang-format-7=1:7-3~ubuntu0.18.04.1 \
-        clang-tidy-7=1:7-3~ubuntu0.18.04.1 \
-        patch=2.7.6-2ubuntu1.1 \
-        software-properties-common=0.96.24.32.14 \
-    # Update to latest git version because of github actions
-    # https://github.com/actions/checkout/issues/126
-    && apt-add-repository ppa:git-core/ppa \
-    && apt-get install -y --no-install-recommends \
-        git \
+        clang-format-7=1:7.0.1-8+deb10u2 \
+        clang-tidy-7=1:7.0.1-8+deb10u2 \
+        patch=2.7.6-3+deb10u1 \
+        software-properties-common=0.96.20.2-2 \
     && rm -rf \
         /tmp/* \
         /var/{cache,log}/* \

--- a/gen.py
+++ b/gen.py
@@ -8,25 +8,24 @@ qemu_path = root_path / 'qemu'
 build_dir = root_path / 'build'
 
 
-def gen_hassio(hassio_arch, base_arch):
+def gen_hassio(hassio_arch):
     d = build_dir / hassio_arch
     d.mkdir(exist_ok=True, parents=True)
     temp = hassio_template.read_text()
     target = d / 'Dockerfile.hassio'
     temp = temp.replace('__HASSIO_ARCH__', hassio_arch)
-    temp = temp.replace('__UBUNTU_BASE_ARCH__', base_arch)
     temp = "# This is an auto-generated file, please edit template/Dockerfile.hassio!\n" + temp
     print("Generating {}".format(target))
     target.write_text(temp)
 
 
 HASSIO_ARCHS = [
-    ('amd64', 'amd64'),
-    ('armv7', 'armv7'),
-    ('aarch64', 'aarch64'),
+    'amd64',
+    'armv7',
+    'aarch64',
 ]
-for arch, base_arch in HASSIO_ARCHS:
-    gen_hassio(arch, base_arch)
+for arch in HASSIO_ARCHS:
+    gen_hassio(arch)
 
 
 def gen_docker(target_arch, docker_arch):

--- a/template/Dockerfile
+++ b/template/Dockerfile
@@ -1,17 +1,17 @@
-FROM __DOCKER_ARCH__/ubuntu:bionic-20210222
+FROM __DOCKER_ARCH__/debian:buster-20210311-slim
 
 RUN \
     apt-get update \
     # Use pinned versions so that we get updates with build caching
     && apt-get install -y --no-install-recommends \
-        python3=3.6.7-1~18.04 \
-        python3-pip=9.0.1-2.3~ubuntu1.18.04.4 \
-        python3-setuptools=39.0.1-2 \
-        python3-pil=5.1.0-1ubuntu0.5 \
-        python3-cryptography=2.1.4-1ubuntu1.4 \
-        iputils-ping=3:20161105-1ubuntu3 \
-        git=1:2.17.1-1ubuntu0.8 \
-        curl=7.58.0-2ubuntu3.12 \
+        python3=3.7.3-1 \
+        python3-pip=18.1-5 \
+        python3-setuptools=40.8.0-1 \
+        python3-pil=5.4.1-2+deb10u2 \
+        python3-cryptography=2.6.1-3+deb10u2 \
+        iputils-ping=3:20180629-2+deb10u1 \
+        git=1:2.20.1-2+deb10u3 \
+        curl=7.64.0-4+deb10u1 \
     && rm -rf \
         /tmp/* \
         /var/{cache,log}/* \

--- a/template/Dockerfile.hassio
+++ b/template/Dockerfile.hassio
@@ -1,4 +1,4 @@
-FROM ghcr.io/hassio-addons/ubuntu-base/__UBUNTU_BASE_ARCH__:6.1.3
+FROM ghcr.io/hassio-addons/debian-base/__UBUNTU_BASE_ARCH__:4.1.3
 
 # Set shell
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
@@ -7,15 +7,15 @@ RUN \
     apt-get update \
     # Use pinned versions so that we get updates with build caching
     && apt-get install -y --no-install-recommends \
-        python3=3.6.7-1~18.04 \
-        python3-pip=9.0.1-2.3~ubuntu1.18.04.4 \
-        python3-setuptools=39.0.1-2 \
-        python3-pil=5.1.0-1ubuntu0.5 \
-        python3-cryptography=2.1.4-1ubuntu1.4 \
-        iputils-ping=3:20161105-1ubuntu3 \
-        git=1:2.17.1-1ubuntu0.8 \
-        curl=7.58.0-2ubuntu3.12 \
-        nginx=1.14.0-0ubuntu1.7 \
+        python3=3.7.3-1 \
+        python3-pip=18.1-5 \
+        python3-setuptools=40.8.0-1 \
+        python3-pil=5.4.1-2+deb10u2 \
+        python3-cryptography=2.6.1-3+deb10u2 \
+        iputils-ping=3:20180629-2+deb10u1 \
+        git=1:2.20.1-2+deb10u3 \
+        curl=7.64.0-4+deb10u1 \
+        nginx=1.14.2-2+deb10u3 \
     && rm -rf \
         /tmp/* \
         /var/{cache,log}/* \

--- a/template/Dockerfile.hassio
+++ b/template/Dockerfile.hassio
@@ -1,4 +1,4 @@
-FROM ghcr.io/hassio-addons/debian-base/__UBUNTU_BASE_ARCH__:4.1.3
+FROM ghcr.io/hassio-addons/debian-base/__HASSIO_ARCH__:4.1.3
 
 # Set shell
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]


### PR DESCRIPTION
Not sure what happened, but debian aarch64 builds are working now.

Replaces https://github.com/esphome/esphome-docker-base/pull/9

New image is based on debian buster and has python 3.7 (was 3.6)