### PR TITLE
Upgrade dependencies

### DIFF
--- a/template/Dockerfile
+++ b/template/Dockerfile
@@ -1,4 +1,4 @@
-FROM __DOCKER_ARCH__/debian:buster-20210311-slim
+FROM __DOCKER_ARCH__/debian:buster-20210329-slim
 
 RUN \
     apt-get update \
@@ -9,9 +9,9 @@ RUN \
         python3-setuptools=40.8.0-1 \
         python3-pil=5.4.1-2+deb10u2 \
         python3-cryptography=2.6.1-3+deb10u2 \
-        iputils-ping=3:20180629-2+deb10u1 \
+        iputils-ping=3:20180629-2+deb10u2 \
         git=1:2.20.1-2+deb10u3 \
-        curl=7.64.0-4+deb10u1 \
+        curl=7.64.0-4+deb10u2 \
     && rm -rf \
         /tmp/* \
         /var/{cache,log}/* \

--- a/template/Dockerfile.hassio
+++ b/template/Dockerfile.hassio
@@ -1,4 +1,4 @@
-FROM ghcr.io/hassio-addons/debian-base/__HASSIO_ARCH__:4.1.3
+FROM ghcr.io/hassio-addons/debian-base/__HASSIO_ARCH__:4.1.4
 
 # Set shell
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
@@ -12,9 +12,9 @@ RUN \
         python3-setuptools=40.8.0-1 \
         python3-pil=5.4.1-2+deb10u2 \
         python3-cryptography=2.6.1-3+deb10u2 \
-        iputils-ping=3:20180629-2+deb10u1 \
+        iputils-ping=3:20180629-2+deb10u2 \
         git=1:2.20.1-2+deb10u3 \
-        curl=7.64.0-4+deb10u1 \
+        curl=7.64.0-4+deb10u2 \
         nginx=1.14.2-2+deb10u3 \
     && rm -rf \
         /tmp/* \


### PR DESCRIPTION
- Main base image: `debian:buster-20210311-slim` -> `debian:buster-20210329-slim`
- HassIO base image: `debian-base/{arch}:4.1.3` -> `debian-base/{arch}:4.1.4`
- `iputils-ping`: `3:20180629-2+deb10u1` -> `3:20180629-2+deb10u2`
- `curl`: `7.64.0-4+deb10u1` -> `7.64.0-4+deb10u2`