### PR TITLE
Remove python3-pil from docker images

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -60,7 +60,7 @@ apt update
 PKG=...
 apt-cache show $PKG | grep 'Version: ' | sed -E 's/Version: (.*)/\1/' | head -1
 
-for PKG in python3 python3-pip python3-setuptools python3-pil python3-cryptography iputils-ping git curl nginx clang-format-7 clang-tidy-7 patch software-properties-common; do
+for PKG in python3 python3-pip python3-setuptools python3-cryptography iputils-ping git curl nginx clang-format-7 clang-tidy-7 patch software-properties-common; do
   vers=$(apt-cache show $PKG | grep 'Version: ' | sed -E 's/Version: (.*)/\1/' | head -1)
   echo "        $PKG=$vers \\"
 done

--- a/template/Dockerfile
+++ b/template/Dockerfile
@@ -7,7 +7,6 @@ RUN \
         python3=3.7.3-1 \
         python3-pip=18.1-5 \
         python3-setuptools=40.8.0-1 \
-        python3-pil=5.4.1-2+deb10u2 \
         python3-cryptography=2.6.1-3+deb10u2 \
         iputils-ping=3:20180629-2+deb10u2 \
         git=1:2.20.1-2+deb10u3 \

--- a/template/Dockerfile.hassio
+++ b/template/Dockerfile.hassio
@@ -10,7 +10,6 @@ RUN \
         python3=3.7.3-1 \
         python3-pip=18.1-5 \
         python3-setuptools=40.8.0-1 \
-        python3-pil=5.4.1-2+deb10u2 \
         python3-cryptography=2.6.1-3+deb10u2 \
         iputils-ping=3:20180629-2+deb10u2 \
         git=1:2.20.1-2+deb10u3 \


### PR DESCRIPTION
See also https://github.com/esphome/esphome/pull/1758#issuecomment-846620025

`pillow` can be installed on all supported docker platforms directly from PyPi. Prefer using the latest PyPi version instead of the one shipped from debian as it's more recent.

`python3-cryptography` is similar, but for there don't appear to be pre-built binaries, and compiling would require a full rust toolchain.