### PR TITLE
Re-add python3-pil to docker images

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -60,7 +60,7 @@ apt update
 PKG=...
 apt-cache show $PKG | grep 'Version: ' | sed -E 's/Version: (.*)/\1/' | head -1
 
-for PKG in python3 python3-pip python3-setuptools python3-cryptography iputils-ping git curl nginx clang-format-7 clang-tidy-7 clang-format-11 clang-tidy-11 patch software-properties-common nano; do
+for PKG in python3 python3-pip python3-setuptools python3-pil python3-cryptography iputils-ping git curl nginx clang-format-7 clang-tidy-7 clang-format-11 clang-tidy-11 patch software-properties-common nano; do
   vers=$(apt-cache show $PKG | grep 'Version: ' | sed -E 's/Version: (.*)/\1/' | head -1)
   echo "        $PKG=$vers \\"
 done

--- a/template/Dockerfile
+++ b/template/Dockerfile
@@ -7,6 +7,7 @@ RUN \
         python3=3.7.3-1 \
         python3-pip=18.1-5 \
         python3-setuptools=40.8.0-1 \
+        python3-pil=5.4.1-2+deb10u2 \
         python3-cryptography=2.6.1-3+deb10u2 \
         iputils-ping=3:20180629-2+deb10u2 \
         git=1:2.20.1-2+deb10u3 \

--- a/template/Dockerfile.hassio
+++ b/template/Dockerfile.hassio
@@ -10,6 +10,7 @@ RUN \
         python3=3.7.3-1 \
         python3-pip=18.1-5 \
         python3-setuptools=40.8.0-1 \
+        python3-pil=5.4.1-2+deb10u2 \
         python3-cryptography=2.6.1-3+deb10u2 \
         iputils-ping=3:20180629-2+deb10u2 \
         git=1:2.20.1-2+deb10u3 \


### PR DESCRIPTION
This reverts commit 90b0c9b85aa355a2c0d0493d29ce6ba93768b093.

See also https://github.com/esphome/esphome/pull/1879#issuecomment-857062894

aarch64 does not have any matching pre-built binaries on PyPi.