### PR TITLE
Lint image add compiler and python3-dev

### DIFF
--- a/Dockerfile.lint
+++ b/Dockerfile.lint
@@ -18,6 +18,8 @@ RUN \
         patch=2.7.6-3+deb10u1 \
         software-properties-common=0.96.20.2-2 \
         nano=3.2-3 \
+        build-essential=12.6 \
+        python3-dev=3.7.3-1 \
     && rm -rf \
         /tmp/* \
         /var/{cache,log}/* \

--- a/NOTES.md
+++ b/NOTES.md
@@ -58,7 +58,7 @@ apt update
 PKG=...
 apt-cache show $PKG | grep 'Version: ' | sed -E 's/Version: (.*)/\1/' | head -1
 
-for PKG in python3 python3-pip python3-setuptools python3-pil python3-cryptography iputils-ping git curl nginx clang-format-7 clang-tidy-7 clang-format-11 clang-tidy-11 patch software-properties-common nano; do
+for PKG in python3 python3-pip python3-setuptools python3-pil python3-cryptography iputils-ping git curl nginx clang-format-7 clang-tidy-7 clang-format-11 clang-tidy-11 patch software-properties-common nano build-essential python3-dev; do
   vers=$(apt-cache show $PKG | grep 'Version: ' | sed -E 's/Version: (.*)/\1/' | head -1)
   echo "        $PKG=$vers \\"
 done


### PR DESCRIPTION
Related to https://github.com/esphome/esphome/pull/2023

On aarch64 typed-ast (a pylint dependency) does not have prebuilt packages. Install compiler and python3 headers to fix that (increased image size not a big issue because it's only the lint image anyway)